### PR TITLE
Fixed correlation coefficient calculation

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -316,7 +316,11 @@
 				return (num - meanX) / stdDevX;
 			});
 			yCoords.map(function(num) {
-				return (num - meanY) / stdDevY;
+				if (stdDevY === 0) {
+					return 0;
+				} else {
+					return (num - meanY) / stdDevY;
+				}
 			});
 
 			// Multiply each element in the x by the corresponding value in

--- a/test/test.js
+++ b/test/test.js
@@ -128,6 +128,20 @@ describe('#linReg()', function() {
 		expect(reg.yIntercept).to.be.within(.00001).of(3.61352);
 		expect(reg.r).to.be.within(.000001).of(-.693356);
 	});
+
+	it('should not return NaN if the y coordinate values are same', function() {
+		var reg1 = stats([
+			{ x: 1,  y: 4 },
+			{ x: 3,  y: 4 },
+			{ x: 6,  y: 4 },
+			{ x: 4,  y: 4 },
+			{ x: 9,  y: 4 },
+		]).linReg();
+
+		expect(reg1.slope).to.eql(0);
+		expect(reg1.yIntercept).to.eql(4);
+		expect(reg1.r).to.eql(0);
+	});
 });
 
 describe('#powReg()', function() {


### PR DESCRIPTION
Originally, I found out the issue by calculating linear regression `linreg()` of points parallel to x-axis.
- Correlation coefficient r() was returning NaN if the standard deviation of y was 0 (because all y values were equal)
- Added test for calculating linear regression with points containing same y coordinate values

Let me know if I need to do anything else to get it merged. Thanks.
